### PR TITLE
Make more ~idiot~ bob-proof..

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ A starter skeleton for a Bolt v3.x Extension
 
 To get going run the following command, replacing the last argument with the name of your extension:
 
-`composer create-project --no-install bolt/bolt-extension-starter:^3.0 <newextname>`  
+`composer create-project --no-install 'bolt/bolt-extension-starter:^3.0' <newextname>`  
 
 For more information, see this page in the Bolt documentation: https://docs.bolt.cm/extensions/building-starter/about


### PR DESCRIPTION
Fix this: 

```
[bob:...rigin/extensions/local/bolt]$ composer create-project --no-install bolt/bolt-extension-starter:^3.0 dummy                             (master)
zsh: no matches found: bolt/bolt-extension-starter:^3.0
[bob:...rigin/extensions/local/bolt]$ composer create-project --no-install 'bolt/bolt-extension-starter:^3.0' dummy                           (master)
Installing bolt/bolt-extension-starter (3.0.0)
  - Installing bolt/bolt-extension-starter (3.0.0)
    Downloading: 100%

Created project in dummy
[bob:...rigin/extensions/local/bolt]$
```
